### PR TITLE
Add function to manually set game date and time.

### DIFF
--- a/.vs/VSWorkspaceState.json
+++ b/.vs/VSWorkspaceState.json
@@ -1,0 +1,7 @@
+{
+  "ExpandedNodes": [
+    ""
+  ],
+  "SelectedNode": "\\engine.sln",
+  "PreviewInSolutionExplorer": false
+}

--- a/SourcesAXR/xrGame/alife_time_manager.h
+++ b/SourcesAXR/xrGame/alife_time_manager.h
@@ -34,6 +34,7 @@ public:
 	IC		float					normal_time_factor		() const;
 	IC		void					change_game_time		(u32 value);
 	IC		void					set_game_time_factor	(ALife::_TIME_ID gameTime, const float timeFactor);
+	IC		void					set_date_time			(u64 date_time);
 };
 
 #include "alife_time_manager_inline.h"

--- a/SourcesAXR/xrGame/alife_time_manager_inline.h
+++ b/SourcesAXR/xrGame/alife_time_manager_inline.h
@@ -1,3 +1,4 @@
+#include "alife_time_manager.h"
 ////////////////////////////////////////////////////////////////////////////
 //	Module 		: alife_time_manager_inline.h
 //	Created 	: 05.01.2003
@@ -45,5 +46,12 @@ IC void CALifeTimeManager::set_game_time_factor(ALife::_TIME_ID gameTime, const 
 	m_game_time = gameTime;
 	m_start_time = Device.dwTimeGlobal;
 	m_time_factor = timeFactor;
+}
+
+IC void CALifeTimeManager::set_date_time(u64 date_time)
+{
+	m_start_game_time = date_time;
+	m_game_time = m_start_game_time;
+	m_start_time = Device.dwTimeGlobal;
 }
 

--- a/SourcesAXR/xrGame/level_script.cpp
+++ b/SourcesAXR/xrGame/level_script.cpp
@@ -235,6 +235,21 @@ void change_game_time(u32 days, u32 hours, u32 mins)
 	}
 }
 
+void set_game_date_time(LPCSTR date, LPCSTR time)
+{
+	game_sv_Single* tpGame = smart_cast<game_sv_Single*>(Level().Server->game);
+	if (tpGame && ai().get_alife())
+	{
+		u32	years, months, days, hours, minutes, seconds;
+		sscanf(time, "%d:%d:%d", &hours, &minutes, &seconds);
+		sscanf(date, "%d.%d.%d", &days, &months, &years);
+		auto newTime = generate_time(years, months, days, hours, minutes, seconds);
+		float fValue = static_cast<float>(days * 86400 + hours * 3600 + minutes * 60);
+		g_pGamePersistent->Environment().ChangeGameTime(fValue);
+		tpGame->alife().time_manager().set_date_time(newTime);
+	}
+}
+
 float high_cover_in_direction(u32 level_vertex_id, const Fvector &direction)
 {
 	float			y,p;
@@ -995,6 +1010,8 @@ void CLevel::script_register(lua_State *L)
 		def("get_time_hours",					get_time_hours),
 		def("get_time_minutes",					get_time_minutes),
 		def("change_game_time",					change_game_time),
+
+		def("set_game_date_time",				set_game_date_time), // runtime set new date with time
 
 		def("high_cover_in_direction",			high_cover_in_direction),
 		def("low_cover_in_direction",			low_cover_in_direction),


### PR DESCRIPTION
Added new Lua bind level.set_game_date_time(date, time), date in format "dd.mm.year" and time in format "hh:mm:ss" (both strings).