### PR TITLE
Add function to enable and disable anomaly reaction by story_id.

### DIFF
--- a/SourcesAXR/xrGame/CustomZone.cpp
+++ b/SourcesAXR/xrGame/CustomZone.cpp
@@ -1201,11 +1201,15 @@ bool CCustomZone::Disable()
 void CCustomZone::ZoneEnable()
 {
 	SwitchZoneState(eZoneStateIdle);
+	//ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeInfo, "CCustomZone : set anomaly enabled");
+	//spatial.type |= STYPE_VISIBLEFORAI; //anomaly visible for NPC
 };
 
 void CCustomZone::ZoneDisable()
 {
 	SwitchZoneState(eZoneStateDisabled);
+	//ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeInfo, "CCustomZone : set anomaly disabled");
+	//spatial.type &= ~STYPE_VISIBLEFORAI; //anomaly not visible for NPC
 };
 
 void CCustomZone::StartWind()
@@ -1397,6 +1401,18 @@ void CCustomZone::GoDisabledState()
 	
 	m_ObjectInfoMap.clear		();
 	feel_touch.clear			();
+
+	//spatial.type &= ~STYPE_VISIBLEFORAI; //блокирование воздействия аномалий на НПС
+}
+
+void CCustomZone::SetAIVisibility(bool IsVisible)
+{
+	if (IsVisible) {
+		spatial.type |= STYPE_VISIBLEFORAI;
+	}
+	else {
+		spatial.type &= ~STYPE_VISIBLEFORAI;
+	}
 }
 
 void CCustomZone::GoEnabledState()
@@ -1406,10 +1422,21 @@ void CCustomZone::GoEnabledState()
 		u_EventGen		(P,GE_ZONE_STATE_CHANGE,ID());
 		P.w_u8			(u8(eZoneStateIdle));
 		u_EventSend		(P);
+
+		//spatial.type |= ~STYPE_VISIBLEFORAI; //блокирование воздействия аномалий на НПС
 }
 
 BOOL CCustomZone::feel_touch_on_contact	(CObject *O)
 {
+	//if (m_eZoneState == EZoneState::eZoneStateDisabled && (spatial.type | STYPE_VISIBLEFORAI) != spatial.type)
+
+	//if (m_eZoneState == EZoneState::eZoneStateDisabled) {
+	//	ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeInfo, "CCustomZone : state disabled");
+	//}
+	//else {
+	//	ai().script_engine().script_log(ScriptStorage::eLuaMessageTypeInfo, "CCustomZone : state enabled");
+	//}
+
 	if ((spatial.type | STYPE_VISIBLEFORAI) != spatial.type)
 		return			(FALSE);
 

--- a/SourcesAXR/xrGame/CustomZone.h
+++ b/SourcesAXR/xrGame/CustomZone.h
@@ -69,6 +69,8 @@ public:
 				float	GetMaxPower						()							{return m_fMaxPower;}
 				void	SetMaxPower						(float p)					{m_fMaxPower = p;}
 
+	virtual		void	SetAIVisibility					(bool IsVisible);
+
 	//вычисление силы хита в зависимости от расстояния до центра зоны
 	//относительный размер силы (от 0 до 1)
 				float	RelativePower					(float dist, float nearest_shape_radius);

--- a/SourcesAXR/xrGame/script_game_object.h
+++ b/SourcesAXR/xrGame/script_game_object.h
@@ -607,6 +607,8 @@ public:
 			void				DisableAnomaly			();
 			float				GetAnomalyPower			();
 			void				SetAnomalyPower			(float p);
+			void				SetAnomalyVisibleForAI	();
+			void				SetAnomalyInvisibleForAI();
 			
 	
 			// HELICOPTER

--- a/SourcesAXR/xrGame/script_game_object3.cpp
+++ b/SourcesAXR/xrGame/script_game_object3.cpp
@@ -828,6 +828,18 @@ void CScriptGameObject::SetAnomalyPower(float p)
 	zone->SetMaxPower(p);
 }
 
+void CScriptGameObject::SetAnomalyVisibleForAI()
+{
+	CCustomZone* zone = smart_cast<CCustomZone*>(&object()); THROW(zone);
+	zone->SetAIVisibility(true);
+}
+
+void CScriptGameObject::SetAnomalyInvisibleForAI()
+{
+	CCustomZone* zone = smart_cast<CCustomZone*>(&object()); THROW(zone);
+	zone->SetAIVisibility(false);
+}
+
 bool CScriptGameObject::weapon_strapped	() const
 {
 	CAI_Stalker		*stalker = smart_cast<CAI_Stalker*>(&object());

--- a/SourcesAXR/xrGame/script_game_object_script3.cpp
+++ b/SourcesAXR/xrGame/script_game_object_script3.cpp
@@ -243,6 +243,8 @@ class_<CScriptGameObject> script_register_game_object2(class_<CScriptGameObject>
 		.def("disable_anomaly",             &CScriptGameObject::DisableAnomaly)
 		.def("get_anomaly_power",			&CScriptGameObject::GetAnomalyPower)
 		.def("set_anomaly_power",			&CScriptGameObject::SetAnomalyPower)
+		.def("set_anomaly_visible_for_ai", &CScriptGameObject::SetAnomalyVisibleForAI)
+		.def("set_anomaly_invisible_for_ai", &CScriptGameObject::SetAnomalyInvisibleForAI)
 
 		//HELICOPTER
 		.def("get_helicopter",              &CScriptGameObject::get_helicopter)

--- a/SourcesAXR/xrGame/space_restrictor.cpp
+++ b/SourcesAXR/xrGame/space_restrictor.cpp
@@ -67,7 +67,30 @@ BOOL CSpaceRestrictor::net_Spawn	(CSE_Abstract* data)
 	if (!result)
 		return						(FALSE);
 
-	spatial.type					&= ~STYPE_VISIBLEFORAI;
+	// section = NameObject
+
+	spatial.type					&= ~STYPE_VISIBLEFORAI; //блокирование воздействия аномалий на НПС
+	
+	// Lex Addon (correct by Suhar_) 19.08.2018		(begin)
+	// Включаем воздействие аномалий на НПС (в зависимости от настроек конфига)
+	// Автор идеи: Shredder, доработано: Suhar_
+	/*bool AnomalyCanDamageStalker = false;
+	// Если есть нужная секция
+	if (pSettings->section_exist("npc_additional_engine_options"))
+	{
+		// Если в секции есть нужный параметр
+		if (pSettings->line_exist("npc_additional_engine_options", "anomaly_can_damage_stalker"))
+		{
+			// Если параметр положительный
+			if (pSettings->r_bool("npc_additional_engine_options", "anomaly_can_damage_stalker"))
+				// Запоминаем
+				AnomalyCanDamageStalker = true;
+		}
+	}
+	// Если нужные параметры отсутствуют или установлено отрицательное значение, то запрещаем аномалиям бить сталкеров
+	if (!AnomalyCanDamageStalker)
+		spatial.type &= ~STYPE_VISIBLEFORAI;*/
+	// Lex Addon (correct by Suhar_) 19.08.2018		(end)
 
 	setEnabled						(FALSE);
 	setVisible						(FALSE);


### PR DESCRIPTION
set_anomaly_visible_for_ai - anomaly reacts on NPC set_anomaly_invisible_for_ai - anomaly ignores NPC By default, all anomalies ignores NPC (as in original)